### PR TITLE
Remove "Turbot" from the dashboard and report titles

### DIFF
--- a/dashboards/control/control_alarm_report.sp
+++ b/dashboards/control/control_alarm_report.sp
@@ -1,5 +1,5 @@
 dashboard "turbot_control_alarm_report" {
-  title = "Turbot Controls in Alarm Report"
+  title = "Controls in Alarm Report"
   documentation = file("./dashboards/control/docs/control_alarm_report.md")
   tags = merge(local.control_common_tags, {
     type     = "Report"

--- a/dashboards/control/control_dashboard.sp
+++ b/dashboards/control/control_dashboard.sp
@@ -1,5 +1,5 @@
 dashboard "turbot_control_dashboard" {
-  title = "Turbot Controls Dashboard"
+  title = "Controls Dashboard"
   documentation = file("./dashboards/control/docs/control_dashboard.md")
   tags = merge(local.control_common_tags, {
     type     = "Dashboard"

--- a/dashboards/control/control_error_report.sp
+++ b/dashboards/control/control_error_report.sp
@@ -1,5 +1,5 @@
 dashboard "turbot_control_error_report" {
-  title = "Turbot Controls in Error Report"
+  title = "Controls in Error Report"
   documentation = file("./dashboards/control/docs/control_error_report.md")
   tags = merge(local.control_common_tags, {
     type     = "Report"

--- a/dashboards/control/control_invalid_report.sp
+++ b/dashboards/control/control_invalid_report.sp
@@ -1,5 +1,5 @@
 dashboard "turbot_control_invalid_report" {
-  title = "Turbot Controls in Invalid Report"
+  title = "Controls in Invalid Report"
   documentation = file("./dashboards/control/docs/control_invalid_report.md")
   tags = merge(local.control_common_tags, {
     type     = "Report"

--- a/dashboards/mod/mod_dashboard.sp
+++ b/dashboards/mod/mod_dashboard.sp
@@ -1,5 +1,5 @@
 dashboard "mod_dashboard" {
-  title         = "Turbot Mods Dashboard"
+  title         = "Mods Dashboard"
   documentation = file("./dashboards/mod/docs/mod_dashboard.md")
   tags          = merge(local.mod_common_tags, {
     type     = "Dashboard"

--- a/dashboards/workspace/workspace_account_report.sp
+++ b/dashboards/workspace/workspace_account_report.sp
@@ -1,5 +1,4 @@
 dashboard "workspace_account_report" {
-
   title         = "Account Report"
   documentation = file("./dashboards/workspace/docs/workspace_account_report.md")
   tags = merge(local.workspace_common_tags, {

--- a/dashboards/workspace/workspace_dashboard.sp
+++ b/dashboards/workspace/workspace_dashboard.sp
@@ -1,9 +1,6 @@
-
 dashboard "workspace_dashboard" {
-
   title         = "Workspace Dashboard"
   documentation = file("./dashboards/workspace/docs/workspace_dashboard.md")
-
   tags = merge(local.workspace_common_tags, {
     type     = "Dashboard"
     category = "Summary"


### PR DESCRIPTION
Since we are already in a Turbot mod, having "Turbot" in the dashboard and report titles is just noisy.